### PR TITLE
Fix echoing empty lines in batch file

### DIFF
--- a/init.bat
+++ b/init.bat
@@ -39,7 +39,7 @@ if not exist "%input_file%" (
         setlocal enabledelayedexpansion
         set "line=!line:%modname%=%replacename%!"
         set "line=!line:%namespace%=%replacenamespace%!"
-        echo !line!
+        echo.!line!
         endlocal
     )
 ) > "%output_file%"


### PR DESCRIPTION
Currently, when there are empty lines in the template file, 'ECHO is off.' is written to the output file (as if calling echo without arguments) when using init.bat, resulting in invalid C#

Ex:
```
using System;
using MyTest.Mod;
using HarmonyLib;
using StationeersMods.Interface;
[StationeersMod("MyTestMod","MyTestMod [StationeersMods]","0.2.4657.21547.1")]
public class MyTestMod : ModBehaviour
{
    // private ConfigEntry<bool> configBool;
ECHO is off.
    public override void OnLoaded(ContentHandler contentHandler)
    {
        UnityEngine.Debug.Log("MyTestMod says: Hello World!");
ECHO is off.
        //Config example
        // configBool = Config.Bind("Input",
        //     "Boolean",
        //     true,
        //     "Boolean description");
ECHO is off.
        Harmony harmony = new Harmony("MyTestMod");
        PrefabPatch.prefabs = contentHandler.prefabs;
        harmony.PatchAll();
        UnityEngine.Debug.Log("MyTestMod Loaded with " + contentHandler.prefabs.Count + " prefab(s)");
    }
}
```

Using `echo.!line!` fixes that